### PR TITLE
fix: video标签的poster属性在鸿蒙的video组件没有应用

### DIFF
--- a/library/src/main/ets/components/hprichtext/index.d.ts
+++ b/library/src/main/ets/components/hprichtext/index.d.ts
@@ -63,6 +63,7 @@ export interface FancyImageOptions extends ShapeAttr {
 export interface FancyVideoOptions {
   width?: string | number;
   height?: string | number;
+  previewUri?: string;
 }
 
 export interface FancyTextInputOptions {


### PR DESCRIPTION
Closes #117