### PR TITLE
fix: Text 节点 wordBreak 不生效

### DIFF
--- a/entry/src/ohosTest/ets/test/List.test.ets
+++ b/entry/src/ohosTest/ets/test/List.test.ets
@@ -1,5 +1,7 @@
 import abilityTest from './Ability.test'
+import wordBreakTest from './WordBreak.test'
 
 export default function testsuite() {
   abilityTest()
+  wordBreakTest()
 }

--- a/entry/src/ohosTest/ets/test/WordBreak.test.ets
+++ b/entry/src/ohosTest/ets/test/WordBreak.test.ets
@@ -1,0 +1,61 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { HTMLParser, parseToArtUI, WordBreak } from '@ohasasugar/hp-richtext'
+import type { NodeInfo } from '@ohasasugar/hp-richtext'
+
+function findFirstElement(nodes?: NodeInfo[], tag?: string): NodeInfo | undefined {
+  if (!nodes?.length) {
+    return undefined;
+  }
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (node.node === 'element' && (!tag || node.tag === tag)) {
+      return node;
+    }
+    const child = findFirstElement(node.nodes, tag);
+    if (child) {
+      return child;
+    }
+  }
+  return undefined;
+}
+
+export default function wordBreakTest() {
+  describe('WordBreakStylePipeline', () => {
+    it('parseToArtUI_mapsCssWordBreakToArkUIEnum', 0, () => {
+      expect(parseToArtUI({ 'word-break': 'normal' }).wordBreak).assertEqual(WordBreak.NORMAL);
+      expect(parseToArtUI({ 'word-break': 'break-all' }).wordBreak).assertEqual(WordBreak.BREAK_ALL);
+      expect(parseToArtUI({ 'word-break': 'break-word' }).wordBreak).assertEqual(WordBreak.BREAK_WORD);
+    })
+
+    it('htmlParser_appliesWordBreakOnTextHostAndInherits', 0, () => {
+      const parser = new HTMLParser({
+        content: '<p style="word-break: break-all"><span>ABC123</span></p>'
+      });
+      const result = parser.html2json();
+      const pNode = findFirstElement(result.nodes, 'p');
+      const spanNode = findFirstElement(result.nodes, 'span');
+      expect(pNode?.artUIStyleObject?.wordBreak).assertEqual(WordBreak.BREAK_ALL);
+      expect(spanNode?.artUIStyleObject?.wordBreak).assertEqual(WordBreak.BREAK_ALL);
+    })
+
+    it('richTextOption_wordBreak_reachesArtUIStyleObject', 0, () => {
+      const parser = new HTMLParser({
+        content: '<p>ABC123</p>',
+        wordBreak: WordBreak.NORMAL
+      });
+      const result = parser.html2json();
+      const pNode = findFirstElement(result.nodes, 'p');
+      expect(pNode?.artUIStyleObject?.wordBreak).assertEqual(WordBreak.NORMAL);
+    })
+
+    it('cssWordBreak_overridesRichTextOptionDefault', 0, () => {
+      const parser = new HTMLParser({
+        content: '<p style="word-break: break-word">ABC123</p>',
+        wordBreak: WordBreak.NORMAL
+      });
+      const result = parser.html2json();
+      const pNode = findFirstElement(result.nodes, 'p');
+      expect(pNode?.artUIStyleObject?.wordBreak).assertEqual(WordBreak.BREAK_WORD);
+    })
+  })
+}

--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- 🐛 修复 Text 节点 wordBreak 不生效：将 CSS `word-break` / RichTextOption.wordBreak 映射到 ArkUI `Text.wordBreak` [(#115)](https://github.com/asasugar/HPRichText/issues/115)
+
 ## [v3.1.0](https://github.com/asasugar/HPRichText/releases/tag/v3.1.0) (2025-10-10)
 
 ### Features

--- a/library/src/main/ets/common/types/artUIBase.d.ts
+++ b/library/src/main/ets/common/types/artUIBase.d.ts
@@ -69,6 +69,7 @@ export interface OtherAttr {
   lineHeight?: string;
   letterSpacing?: string;
   textAlign?: 0 | 1 | 2 | 3;
+  wordBreak?: 0 | 1 | 2;
 }
 
 export interface Resource {

--- a/library/src/main/ets/common/types/artUIEnum.ts
+++ b/library/src/main/ets/common/types/artUIEnum.ts
@@ -25,6 +25,13 @@ export const enum TextOverflow {
   MARQUEE
 }
 
+// 与 ArkUI Text.wordBreak / WordBreak 枚举值对齐：NORMAL=0, BREAK_ALL=1, BREAK_WORD=2
+export const enum WordBreak {
+  NORMAL,
+  BREAK_ALL,
+  BREAK_WORD
+}
+
 export const enum FontStyle {
   Normal,
   Italic

--- a/library/src/main/ets/common/types/consants.d.ts
+++ b/library/src/main/ets/common/types/consants.d.ts
@@ -1,4 +1,13 @@
-import { BorderStyle, Color, FontStyle, TextAlign, TextDecorationType, TextOverflow, Visibility } from './artUIEnum';
+import {
+  BorderStyle,
+  Color,
+  FontStyle,
+  TextAlign,
+  TextDecorationType,
+  TextOverflow,
+  Visibility,
+  WordBreak
+} from './artUIEnum';
 
 export type AttrsMap = Record<string, string | Record<string, string[]>>;
 
@@ -46,6 +55,11 @@ export interface AttrEnums {
       clip: TextOverflow;
       none: TextOverflow;
     };
+  };
+  'wordBreak': {
+    normal: WordBreak;
+    'break-all': WordBreak;
+    'break-word': WordBreak;
   };
 }
 

--- a/library/src/main/ets/common/types/htmlParser.d.ts
+++ b/library/src/main/ets/common/types/htmlParser.d.ts
@@ -90,6 +90,7 @@ export interface StyleObject {
   'text-overflow'?: string;
   '-webkit-line-clamp'?: number;
   'text-align'?: 'start' | 'end' | 'center' | 'justify';
+  'word-break'?: 'normal' | 'break-all' | 'break-word';
   'display'?: 'inline' | 'block';
 }
 

--- a/library/src/main/ets/common/utils/css/constants.ts
+++ b/library/src/main/ets/common/utils/css/constants.ts
@@ -1,4 +1,4 @@
-import { BorderStyle, TextAlign, TextDecorationType, TextOverflow } from '../../types/artUIEnum';
+import { BorderStyle, TextAlign, TextDecorationType, TextOverflow, WordBreak } from '../../types/artUIEnum';
 import type { AttrEnums, AttrsMap } from '../../types/consants';
 
 // 支持的html样式key转化为鸿蒙样式key
@@ -33,6 +33,7 @@ export const attrsMap: AttrsMap = {
   'font-weight': 'fontWeight',
   'font-family': 'fontFamily',
   'text-align': 'textAlign',
+  'word-break': 'wordBreak',
 };
 
 
@@ -60,6 +61,11 @@ export const attrEnums: AttrEnums = {
       'clip': TextOverflow.Clip,
       'none': TextOverflow.None
     }
+  },
+  'wordBreak': {
+    'normal': WordBreak.NORMAL,
+    'break-all': WordBreak.BREAK_ALL,
+    'break-word': WordBreak.BREAK_WORD
   }
 }
 

--- a/library/src/main/ets/common/utils/html/html-parser.ts
+++ b/library/src/main/ets/common/utils/html/html-parser.ts
@@ -69,6 +69,7 @@ class HTMLParser {
   private basePixelUnit: PixelUnit = 'vp';
   private basePixelRatio: number | Resource = 1;
   private baseFontColor: string | Resource = '#000000';
+  private wordBreak?: 0 | 1 | 2;
   private last: string = '';
 
   constructor(
@@ -79,7 +80,8 @@ class HTMLParser {
       basePixelUnit,
       basePixelRatio,
       baseFontColor,
-      content
+      content,
+      wordBreak
     }: RichTextOption) {
     customHandler && (this.customHandler = customHandler);
     imageProp && Object.assign(this.imageProp, imageProp);
@@ -88,6 +90,7 @@ class HTMLParser {
     basePixelRatio && (this.basePixelRatio = basePixelRatio);
     baseFontColor && (this.baseFontColor = baseFontColor);
     content && (this.html = content);
+    wordBreak !== undefined && (this.wordBreak = wordBreak);
   }
 
   start(tag: string, attrs: Attribute[], unary: boolean) {
@@ -208,9 +211,11 @@ class HTMLParser {
     let htmlStyles = {};
     htmlStyles = setHtmlAttributes(this.baseFontSize as number, this.baseFontColor as string, node.tag);
 
-    // 整合父标签过滤之后的标签默认样式+可继承样式+自身style样式【顺序很重要】
+    // 整合 RichTextOption.wordBreak 默认值+标签默认样式+父标签可继承样式+自身style样式【顺序很重要】
+    // wordBreak 是 CSS 可继承属性，需随 artUIStyleObject 下传到 Text.fancyText
+    const defaultWordBreak = this.wordBreak !== undefined ? { wordBreak: this.wordBreak } : {};
     node.artUIStyleObject =
-      Object.assign({}, htmlStyles, excludeExtendsParentArtUIStyle(parent?.artUIStyleObject, node),
+      Object.assign({}, defaultWordBreak, htmlStyles, excludeExtendsParentArtUIStyle(parent?.artUIStyleObject, node),
         node.artUIStyleObject);
     // 对纯数字的lineHeight样式特别计算
     const lh: number = +(node.artUIStyleObject?.lineHeight ?? 0);
@@ -552,11 +557,15 @@ class HTMLParser {
   }
 
   private defaultArtUI() {
-    return {
+    const style: Record<string, string | number | Color> = {
       fontSize: `${parseInt(String(this?.baseFontSize), 10) *
         (this.basePixelRatio as number)}${this.basePixelUnit}`,
       fontColor: this.baseFontColor as Color
+    };
+    if (this.wordBreak !== undefined) {
+      style.wordBreak = this.wordBreak;
     }
+    return style;
   }
 }
 

--- a/library/src/main/ets/components/hprichtext/HPRichText.ets
+++ b/library/src/main/ets/components/hprichtext/HPRichText.ets
@@ -180,6 +180,7 @@ function fancyText($$: FancyTextOptions = {}) {
   .fontWeight($$.fontWeight)
   .fontFamily($$.fontFamily)
   .textAlign($$.textAlign)
+  .wordBreak($$.wordBreak)
   .textOverflow($$.textOverflow)
   .maxLines($$.maxLines ? Number($$.maxLines) : $$.textOverflow ? 1 : null)
   .border($$.border)

--- a/library/src/main/ets/components/hprichtext/HPRichTextV2.ets
+++ b/library/src/main/ets/components/hprichtext/HPRichTextV2.ets
@@ -182,6 +182,7 @@ function fancyText($$: FancyTextOptions = {}) {
   .fontWeight($$.fontWeight)
   .fontFamily($$.fontFamily)
   .textAlign($$.textAlign)
+  .wordBreak($$.wordBreak)
   .textOverflow($$.textOverflow)
   .maxLines($$.maxLines ? Number($$.maxLines) : $$.textOverflow ? 1 : null)
   .border($$.border)

--- a/library/src/main/ets/components/hprichtext/ObservedHPRichText.ets
+++ b/library/src/main/ets/components/hprichtext/ObservedHPRichText.ets
@@ -173,6 +173,7 @@ function fancyText($$: FancyTextOptions = {}) {
   .fontWeight($$.fontWeight)
   .fontFamily($$.fontFamily)
   .textAlign($$.textAlign)
+  .wordBreak($$.wordBreak)
   .textOverflow($$.textOverflow)
   .maxLines($$.maxLines ? Number($$.maxLines) : $$.textOverflow ? 1 : null)
   .border($$.border)

--- a/library/src/main/ets/components/hprichtext/index.d.ts
+++ b/library/src/main/ets/components/hprichtext/index.d.ts
@@ -43,6 +43,7 @@ export interface FancyTextOptions extends FontAttr, ShapeAttr, PositionAttr {
   lineHeight?: string | number;
   letterSpacing?: string;
   textAlign?: 0 | 1 | 2 | 3;
+  wordBreak?: 0 | 1 | 2;
   textOverflow?: {
     overflow: 0 | 1 | 2 | 3;
   };
@@ -91,6 +92,7 @@ export interface RichTextOption {
   basePixelRatio?: number | Resource;
   imageProp?: ImageProp;
   customHandler?: CustomHandler;
+  wordBreak?: 0 | 1 | 2;
 }
 
 export interface LinkPressParame {

--- a/library/src/main/ets/components/hprichtext/model/RichTextOptionModel.ets
+++ b/library/src/main/ets/components/hprichtext/model/RichTextOptionModel.ets
@@ -10,4 +10,5 @@ export class RichTextOptionModel {
   basePixelRatio?: number | Resource;
   imageProp?: ImageProp;
   customHandler?: CustomHandler;
+  wordBreak?: 0 | 1 | 2;
 }

--- a/library/src/main/ets/components/hprichtext/model/RichTextOptionModelV2.ets
+++ b/library/src/main/ets/components/hprichtext/model/RichTextOptionModelV2.ets
@@ -9,6 +9,7 @@ export class RichTextOption {
   basePixelRatio?: number | Resource;
   imageProp?: ImageProp;
   customHandler?: CustomHandler;
+  wordBreak?: 0 | 1 | 2;
 }
 
 

--- a/test/wordBreak.test.mjs
+++ b/test/wordBreak.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Node parser test for the Text.wordBreak style pipeline.
+ * Bundles the library CSS/HTML parser (no HarmonyOS device required).
+ */
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const cssEntry = join(repoRoot, 'library/src/main/ets/common/utils/css/index.ts');
+const parserEntry = join(repoRoot, 'library/src/main/ets/common/utils/html/html-parser.ts');
+
+function bundle(entry) {
+  const outDir = mkdtempSync(join(tmpdir(), 'hprichtext-wordbreak-'));
+  const outfile = join(outDir, 'bundle.cjs');
+  const result = spawnSync('npx', [
+    '--yes',
+    'esbuild',
+    entry,
+    '--bundle',
+    '--platform=node',
+    '--format=cjs',
+    `--outfile=${outfile}`
+  ], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`esbuild failed for ${entry}:\n${result.stderr || result.stdout}`);
+  }
+  return createRequire(import.meta.url)(outfile);
+}
+
+function findFirstElement(nodes, tag) {
+  if (!nodes?.length) {
+    return undefined;
+  }
+  for (const node of nodes) {
+    if (node.node === 'element' && (!tag || node.tag === tag)) {
+      return node;
+    }
+    const child = findFirstElement(node.nodes, tag);
+    if (child) {
+      return child;
+    }
+  }
+  return undefined;
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+}
+
+const WordBreak = {
+  NORMAL: 0,
+  BREAK_ALL: 1,
+  BREAK_WORD: 2
+};
+
+const { parseToArtUI } = bundle(cssEntry);
+const HTMLParser = bundle(parserEntry).default;
+
+assertEqual(parseToArtUI({ 'word-break': 'normal' }).wordBreak, WordBreak.NORMAL,
+  'CSS word-break:normal');
+assertEqual(parseToArtUI({ 'word-break': 'break-all' }).wordBreak, WordBreak.BREAK_ALL,
+  'CSS word-break:break-all');
+assertEqual(parseToArtUI({ 'word-break': 'break-word' }).wordBreak, WordBreak.BREAK_WORD,
+  'CSS word-break:break-word');
+assertEqual(parseToArtUI({ 'text-align': 'center' }).textAlign, 1,
+  'existing textAlign mapping still works');
+assertEqual(parseToArtUI({ color: 'red' }).wordBreak, undefined,
+  'unrelated CSS must not invent wordBreak');
+
+const cssParser = new HTMLParser({
+  content: '<p style="word-break: break-all"><span>ABC123</span></p>'
+});
+const cssResult = cssParser.html2json();
+const pNode = findFirstElement(cssResult.nodes, 'p');
+const spanNode = findFirstElement(cssResult.nodes, 'span');
+assertEqual(pNode?.artUIStyleObject?.wordBreak, WordBreak.BREAK_ALL,
+  'p.artUIStyleObject.wordBreak from CSS');
+assertEqual(spanNode?.artUIStyleObject?.wordBreak, WordBreak.BREAK_ALL,
+  'span inherits parent wordBreak');
+
+const optionParser = new HTMLParser({
+  content: '<p>ABC123</p>',
+  wordBreak: WordBreak.NORMAL
+});
+const optionResult = optionParser.html2json();
+const optionP = findFirstElement(optionResult.nodes, 'p');
+assertEqual(optionP?.artUIStyleObject?.wordBreak, WordBreak.NORMAL,
+  'RichTextOption.wordBreak reaches artUIStyleObject');
+
+const overrideParser = new HTMLParser({
+  content: '<p style="word-break: break-word">ABC123</p>',
+  wordBreak: WordBreak.NORMAL
+});
+const overrideP = findFirstElement(overrideParser.html2json().nodes, 'p');
+assertEqual(overrideP?.artUIStyleObject?.wordBreak, WordBreak.BREAK_WORD,
+  'inline CSS word-break overrides RichTextOption.wordBreak');
+
+const fancyTextFiles = [
+  'library/src/main/ets/components/hprichtext/HPRichText.ets',
+  'library/src/main/ets/components/hprichtext/HPRichTextV2.ets',
+  'library/src/main/ets/components/hprichtext/ObservedHPRichText.ets'
+];
+for (const relative of fancyTextFiles) {
+  const source = readFileSync(join(repoRoot, relative), 'utf8');
+  if (!source.includes('.wordBreak($$.wordBreak)')) {
+    throw new Error(`${relative} does not apply Text.wordBreak from artUIStyleObject`);
+  }
+}
+
+console.log('wordBreak style pipeline tests passed');


### PR DESCRIPTION
## Summary
- CSS `word-break` and `RichTextOption.wordBreak` now map to ArkUI `Text.wordBreak`.
- Style inheritance applies the value; `fancyText` actually calls `.wordBreak(...)`.
- Node tests cover mapping, inheritance, option default, and CSS override.

Fixes #115

## Test plan
- [ ] `node test/wordBreak.test.mjs`
- [ ] HTML `style="word-break: break-all"` wraps long tokens on Text nodes
- [ ] `RichTextOption.wordBreak` is used when CSS does not set it