### PR TITLE
fix: Image constraintSize no longer breaks objectFit=Contain

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- 🐛
+  修复 Image constraintSize 默认 maxHeight: 100% 导致 objectFit=Contain 失效
+  [(#113)](https://github.com/asasugar/HPRichText/issues/113)
+
 ## [v3.1.0](https://github.com/asasugar/HPRichText/releases/tag/v3.1.0) (2025-10-10)
 
 ### Features

--- a/library/index.ets
+++ b/library/index.ets
@@ -9,6 +9,7 @@ export type {
   CustomHandler,
   HeadingStyle,
   HtmlParserResult,
+  ImageConstraintSize,
   ImageProp,
   NodeInfo,
   Nullable,

--- a/library/src/main/ets/common/types/htmlParser.d.ts
+++ b/library/src/main/ets/common/types/htmlParser.d.ts
@@ -22,11 +22,19 @@ export interface NodeInfo extends SimpleNode {
   addHarmonyTextTag?: boolean;
 }
 
+export interface ImageConstraintSize {
+  minWidth?: string | number;
+  maxWidth?: string | number;
+  minHeight?: string | number;
+  maxHeight?: string | number;
+}
+
 export interface ImageProp {
   objectFit?: 'Contain' | 'Cover' | 'Auto' | 'Fill' | 'ScaleDown' | 'None';
   margin?: number | string;
   webp?: boolean;
   copyEnable?: boolean;
+  constraintSize?: ImageConstraintSize;
 }
 
 export interface CustomHandler {

--- a/library/src/main/ets/common/utils/imageConstraintSize.ts
+++ b/library/src/main/ets/common/utils/imageConstraintSize.ts
@@ -1,0 +1,49 @@
+import type { ImageConstraintSize } from '../types/htmlParser';
+
+export type { ImageConstraintSize };
+
+function hasDefinedLimit(limits?: ImageConstraintSize | null): boolean {
+  if (!limits) {
+    return false;
+  }
+  return limits.minWidth !== undefined
+    || limits.maxWidth !== undefined
+    || limits.minHeight !== undefined
+    || limits.maxHeight !== undefined;
+}
+
+function pickDefinedLimits(limits: ImageConstraintSize): ImageConstraintSize {
+  const resolved: ImageConstraintSize = {};
+  if (limits.minWidth !== undefined) {
+    resolved.minWidth = limits.minWidth;
+  }
+  if (limits.maxWidth !== undefined) {
+    resolved.maxWidth = limits.maxWidth;
+  }
+  if (limits.minHeight !== undefined) {
+    resolved.minHeight = limits.minHeight;
+  }
+  if (limits.maxHeight !== undefined) {
+    resolved.maxHeight = limits.maxHeight;
+  }
+  return resolved;
+}
+
+/**
+ * Resolve Image.constraintSize so it can coexist with objectFit (Contain).
+ *
+ * Issue #107 asked for maxWidth: 100% so wide images do not overflow.
+ * Commit b4f1d31 also hardcoded maxHeight: 100%, which boxes the image to the
+ * parent height and makes objectFit=Contain appear broken (#113).
+ *
+ * - No caller limits: apply maxWidth 100% only (never default maxHeight).
+ * - Caller-provided limits: apply only the keys they actually set.
+ */
+export function resolveImageConstraintSize(
+  callerLimits?: ImageConstraintSize | null
+): ImageConstraintSize {
+  if (hasDefinedLimit(callerLimits)) {
+    return pickDefinedLimits(callerLimits as ImageConstraintSize);
+  }
+  return { maxWidth: '100%' };
+}

--- a/library/src/main/ets/components/hprichtext/builder/image.ets
+++ b/library/src/main/ets/components/hprichtext/builder/image.ets
@@ -1,4 +1,5 @@
 import type { Attr, NodeInfo } from '../../../common/types';
+import { resolveImageConstraintSize } from '../../../common/utils/imageConstraintSize';
 import type { FancyImageOptions, LinkPressMethod, RichTextOption } from '../index';
 import { _commonClick } from '../common';
 
@@ -7,7 +8,9 @@ export function imageBuilder(item: NodeInfo, onLinkPress?: LinkPressMethod, rich
   Image(item.attr?.resource ? $r(item.attr?.src) : item.attr?.src)
     .fancyImage(item?.artUIStyleObject,
       item?.attr)
-    .constraintSize({ maxWidth: "100%", maxHeight: '100%' })
+    // maxWidth-only by default so objectFit=Contain can honor intrinsic height (#113).
+    // Caller-provided imageProp.constraintSize is applied only for keys they set.
+    .constraintSize(resolveImageConstraintSize(richTextOption?.imageProp?.constraintSize))
     .copyOption(richTextOption?.imageProp?.copyEnable ? CopyOptions.InApp : CopyOptions.None)
     .onClick((event) => {
       _commonClick(item, event, { resourceSrc: item.attr?.src }, onLinkPress)

--- a/library/test/imageConstraintSize.test.ts
+++ b/library/test/imageConstraintSize.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveImageConstraintSize } from '../src/main/ets/common/utils/imageConstraintSize.ts';
+
+describe('resolveImageConstraintSize', () => {
+  it('does not apply the #107 maxHeight: 100% default that breaks objectFit Contain', () => {
+    const resolved = resolveImageConstraintSize();
+
+    assert.deepEqual(resolved, { maxWidth: '100%' });
+    assert.equal(resolved.maxHeight, undefined);
+    assert.equal(Object.prototype.hasOwnProperty.call(resolved, 'maxHeight'), false);
+  });
+
+  it('treats empty caller limits as unset and still omits maxHeight', () => {
+    const resolved = resolveImageConstraintSize({});
+
+    assert.deepEqual(resolved, { maxWidth: '100%' });
+    assert.equal(resolved.maxHeight, undefined);
+  });
+
+  it('treats null caller limits as unset', () => {
+    const resolved = resolveImageConstraintSize(null);
+
+    assert.deepEqual(resolved, { maxWidth: '100%' });
+    assert.equal(resolved.maxHeight, undefined);
+  });
+
+  it('applies only the size limits the caller actually set so Contain can coexist', () => {
+    const resolved = resolveImageConstraintSize({ maxWidth: '80%' });
+
+    assert.deepEqual(resolved, { maxWidth: '80%' });
+    assert.equal(resolved.maxHeight, undefined);
+    assert.equal(resolved.minWidth, undefined);
+    assert.equal(resolved.minHeight, undefined);
+  });
+
+  it('preserves an explicit maxHeight when the caller opts into it', () => {
+    const resolved = resolveImageConstraintSize({
+      maxWidth: '100%',
+      maxHeight: '200vp'
+    });
+
+    assert.deepEqual(resolved, {
+      maxWidth: '100%',
+      maxHeight: '200vp'
+    });
+  });
+
+  it('does not invent maxWidth when the caller only set a height limit', () => {
+    const resolved = resolveImageConstraintSize({ maxHeight: '400vp' });
+
+    assert.deepEqual(resolved, { maxHeight: '400vp' });
+    assert.equal(resolved.maxWidth, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #107 hardcoded `.constraintSize({ maxWidth: "100%", maxHeight: "100%" })` on every Image.
- `maxHeight: 100%` boxes the image to the parent height, so `objectFit=Contain` can no longer follow intrinsic aspect ratio.
- Default constraint is now `{ maxWidth: "100%" }` only. Extra limits apply only when the caller sets `imageProp.constraintSize`.

Fixes #113

## Test plan
- [ ] `node --experimental-strip-types --test library/test/imageConstraintSize.test.ts`
- [ ] Images with `objectFit=Contain` keep aspect ratio
- [ ] Explicit `constraintSize` still applies caller-set keys only