### PR TITLE
fix: nested a>span links inherit href so they stay clickable

### DIFF
--- a/entry/src/ohosTest/ets/test/List.test.ets
+++ b/entry/src/ohosTest/ets/test/List.test.ets
@@ -1,5 +1,7 @@
 import abilityTest from './Ability.test'
+import nestedAnchorClickTest from './NestedAnchorClick.test'
 
 export default function testsuite() {
   abilityTest()
+  nestedAnchorClickTest()
 }

--- a/entry/src/ohosTest/ets/test/NestedAnchorClick.test.ets
+++ b/entry/src/ohosTest/ets/test/NestedAnchorClick.test.ets
@@ -1,0 +1,42 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { HTMLParser } from '@ohasasugar/hp-richtext'
+import type { NodeInfo } from '@ohasasugar/hp-richtext'
+
+function findFirstTag(nodes: NodeInfo[] | undefined, tag: string): NodeInfo | undefined {
+  if (!nodes) {
+    return undefined;
+  }
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (node.tag === tag) {
+      return node;
+    }
+    const nested = findFirstTag(node.nodes, tag);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+export default function nestedAnchorClickTest() {
+  describe('NestedAnchorClickTest', function () {
+    it('nested_a_span_inherits_href', 0, function () {
+      const parser = new HTMLParser({
+        content: '<a href="http://www.baidu.com"><span>a标签</span></a>'
+      });
+      const result = parser.html2json();
+      const span = findFirstTag(result.nodes, 'span');
+      expect(span?.attr?.href).assertEqual('http://www.baidu.com');
+    })
+
+    it('nested_a_span_b_inherits_href', 0, function () {
+      const parser = new HTMLParser({
+        content: '<a href="https://example.com"><span><b>deep</b></span></a>'
+      });
+      const result = parser.html2json();
+      const bold = findFirstTag(result.nodes, 'b');
+      expect(bold?.attr?.href).assertEqual('https://example.com');
+    })
+  })
+}

--- a/library/src/main/ets/common/utils/html/click.ts
+++ b/library/src/main/ets/common/utils/html/click.ts
@@ -1,0 +1,50 @@
+import type { NodeInfo } from '../../types/htmlParser';
+
+/**
+ * Nested inline tags inherit ancestor <a> href / onClick so the link still fires
+ * when the click lands on an inner span (or other inline wrapper).
+ */
+export function inheritClickableAttrs(node: NodeInfo, parent?: NodeInfo): void {
+  if (node.tagType !== 'inline' || !parent?.attr) {
+    return;
+  }
+  if (!node.attr) {
+    node.attr = {};
+  }
+  if (parent.attr.href !== undefined && node.attr.href === undefined) {
+    node.attr.href = parent.attr.href;
+  }
+  if (parent.attr.onClick !== undefined && node.attr.onClick === undefined) {
+    node.attr.onClick = parent.attr.onClick;
+  }
+}
+
+export function isClickableNode(node?: NodeInfo): boolean {
+  if (!node) {
+    return false;
+  }
+  return node.tag === 'a' || !!node.attr?.onClick || !!node.attr?.href;
+}
+
+/**
+ * Mirrors spanBuilder onClick gating: a node is clickable when it is an <a>,
+ * has onClick, or inherited href; isInlinePushNode still honors clickIndex.
+ */
+export function shouldFireNodeClick(parentNode?: NodeInfo, index: number = 0): boolean {
+  if (!isClickableNode(parentNode)) {
+    return false;
+  }
+  const clickIndex: number = parentNode?.attr?.clickIndex ?? 0;
+  if (parentNode?.isInlinePushNode && index !== clickIndex) {
+    return false;
+  }
+  return true;
+}
+
+export function resolveLinkPress(parentNode?: NodeInfo, text?: string) {
+  return {
+    text,
+    link: parentNode?.attr?.href,
+    eventFnName: parentNode?.attr?.onClick
+  };
+}

--- a/library/src/main/ets/common/utils/html/html-parser.ts
+++ b/library/src/main/ets/common/utils/html/html-parser.ts
@@ -33,6 +33,7 @@ import {
   startWithHTMLElement,
   trimHtml
 } from './index';
+import { inheritClickableAttrs, isClickableNode } from './click';
 import Node from './node';
 import { px2Any } from './pixelUnit';
 import Stack from './stack';
@@ -204,6 +205,9 @@ class HTMLParser {
 
     this.customHandler?.start?.(node, this.results);
 
+    // Nested inline tags inherit ancestor <a> href / onClick so inner spans stay clickable
+    inheritClickableAttrs(node, parent);
+
     // 子节点继承父节点样式(需要排除不需要继承的样式)
     let htmlStyles = {};
     htmlStyles = setHtmlAttributes(this.baseFontSize as number, this.baseFontColor as string, node.tag);
@@ -223,7 +227,10 @@ class HTMLParser {
       Object.assign(node.artUIStyleObject, { 'lineHeight': `${+numberStr * lh}${this.basePixelUnit}` })
     }
     // 如果是点击事件，则增加触发事件的node节点index
-    if ('onClick' in node.attr || node.tag === 'a') {
+    if (isClickableNode(node)) {
+      if (!node.attr) {
+        node.attr = {};
+      }
       node.attr.clickIndex = 0;
     }
     if (unary) {
@@ -451,7 +458,7 @@ class HTMLParser {
               node.nodes.unshift(parentNodes[parentNodesLength-1]);
               parentNodes.pop();
               node.addHarmonyTextTag = true;
-              if (node.attr && (node.attr?.onClick || node.tag === 'a')) {
+              if (node.attr && isClickableNode(node)) {
                 node.attr.clickIndex += 1;
               }
             }

--- a/library/src/main/ets/components/hprichtext/builder/span.ets
+++ b/library/src/main/ets/components/hprichtext/builder/span.ets
@@ -1,4 +1,5 @@
 import { assign } from '../../../common/utils/helperful';
+import { resolveLinkPress, shouldFireNodeClick } from '../../../common/utils/html/click';
 import type { FancySpanOptions, SpanBuilderInstall, TextBuilderOptions } from '../index';
 import type { StyleObject } from '../../../common/types';
 
@@ -21,43 +22,15 @@ export function spanBuilder($$: TextBuilderOptions, install: SpanBuilderInstall)
   Span($$.node.text)
     .fancySpan(mergeFancySpan($$, install))
     .onClick((event) => {
-
-      let clickIndex: number = $$.parentNode?.attr?.clickIndex ?? 0;
-      // 不触发点击事件的场景：
-      // 判断父级是否为isInlinePushNode的结构：
-      // 是：
-      // a. index!==0
-      // b. 非<a>标签判断不存在onClick属性
-      //
-      // 否：
-      // 非<a>标签判断不存在onClick属性
-
-      // 检查是否为内联推送节点
-      if ($$.parentNode?.isInlinePushNode) {
-        // 对于内联推送节点，检查索引和父节点类型
-        if ($$.index !== clickIndex ||
-          ($$.parentNode?.tag !== 'a' && !$$.parentNode?.attr?.onClick)
-        ) {
-          return;
-        }
-      } else {
-        // 对于非内联推送节点，检查父节点类型
-        if ($$.parentNode?.tag !== 'a' && !$$.parentNode?.attr?.onClick) {
-          return
-        }
-      }
-      if (($$.parentNode?.tag !== 'a' && !$$.parentNode?.attr?.onClick) ||
-        ($$.parentNode?.tag === 'a' && $$.parentNode?.isInlinePushNode && $$.index !== clickIndex)) {
+      // Nested inline tags inherit parent <a> href / onClick (see inheritClickableAttrs)
+      if (!shouldFireNodeClick($$.parentNode, $$.index)) {
         return;
       }
       // 增加回调事件
       try {
-        install.onLinkPress?.({
-          text: $$.node.text,
-          link: $$.parentNode?.attr?.href,
-          eventFnName: $$.parentNode?.attr?.onClick,
+        install.onLinkPress?.(assign(resolveLinkPress($$.parentNode, $$.node.text), {
           clickEvent: event
-        });
+        }));
       } catch (error) {
         console.error(`ErrorCode: ${error.code},  Message: ${error.message}`);
       }

--- a/library/test/click.test.ts
+++ b/library/test/click.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Focused unit tests for nested <a><span> click/href inheritance (#111).
+ * Run: node --experimental-strip-types library/test/click.test.ts
+ */
+import type { NodeInfo } from '../src/main/ets/common/types/htmlParser';
+import {
+  inheritClickableAttrs,
+  isClickableNode,
+  resolveLinkPress,
+  shouldFireNodeClick
+} from '../src/main/ets/common/utils/html/click.ts';
+
+function collectLinkPressFromTree(
+  nodes?: NodeInfo[],
+  parentNode?: NodeInfo
+): Array<{ text?: string; link?: string; eventFnName?: string }> {
+  const result: Array<{ text?: string; link?: string; eventFnName?: string }> = [];
+  if (!nodes?.length) {
+    return result;
+  }
+  for (let i = 0; i < nodes.length; i++) {
+    const item = nodes[i];
+    if (item.node === 'element' && item.nodes?.length) {
+      const nested = collectLinkPressFromTree(item.nodes, item);
+      for (let j = 0; j < nested.length; j++) {
+        result.push(nested[j]);
+      }
+    } else if (item.node === 'text' && shouldFireNodeClick(parentNode, i)) {
+      result.push(resolveLinkPress(parentNode, item.text));
+    }
+  }
+  return result;
+}
+
+let failed = 0;
+let passed = 0;
+
+function assert(cond: boolean, message: string): void {
+  if (cond) {
+    passed += 1;
+    console.log(`  ok  ${message}`);
+  } else {
+    failed += 1;
+    console.error(`  FAIL ${message}`);
+  }
+}
+
+function assertEqual(actual: unknown, expected: unknown, message: string): void {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) {
+    console.error(`    expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+  assert(ok, message);
+}
+
+function issue111Tree(): NodeInfo {
+  const anchor: NodeInfo = {
+    node: 'element',
+    tag: 'a',
+    tagType: 'inline',
+    attr: { href: 'http://www.baidu.com', clickIndex: 0 },
+    nodes: []
+  };
+  const span: NodeInfo = {
+    node: 'element',
+    tag: 'span',
+    tagType: 'inline',
+    attr: {},
+    nodes: [{ node: 'text', text: 'a标签' }]
+  };
+  inheritClickableAttrs(span, anchor);
+  if (isClickableNode(span) && span.attr) {
+    span.attr.clickIndex = 0;
+  }
+  anchor.nodes = [span];
+  return anchor;
+}
+
+console.log('#111 nested a>span inherits href');
+const nested = issue111Tree();
+assertEqual(nested.nodes?.[0]?.attr?.href, 'http://www.baidu.com', 'span inherits parent <a> href');
+assert(isClickableNode(nested.nodes?.[0]), 'nested span is clickable after inherit');
+assert(shouldFireNodeClick(nested.nodes?.[0], 0), 'click on inner span text should fire');
+
+const presses = collectLinkPressFromTree([nested]);
+assertEqual(presses.length, 1, 'exactly one link press from a>span text');
+assertEqual(presses[0]?.link, 'http://www.baidu.com', 'fired link is the inherited href');
+assertEqual(presses[0]?.text, 'a标签', 'fired text is the span content');
+
+console.log('plain <a> text still fires');
+const plainA: NodeInfo = {
+  node: 'element',
+  tag: 'a',
+  tagType: 'inline',
+  attr: { href: 'http://www.baidu.com', clickIndex: 0 },
+  nodes: [{ node: 'text', text: 'a标签' }]
+};
+assert(shouldFireNodeClick(plainA, 0), 'direct <a> text is clickable');
+assertEqual(collectLinkPressFromTree([plainA])[0]?.link, 'http://www.baidu.com', 'direct <a> keeps href');
+
+console.log('non-link span does not fire');
+const lonelySpan: NodeInfo = {
+  node: 'element',
+  tag: 'span',
+  tagType: 'inline',
+  attr: {},
+  nodes: [{ node: 'text', text: 'plain' }]
+};
+assert(!shouldFireNodeClick(lonelySpan, 0), 'span without href/onClick is not clickable');
+assertEqual(collectLinkPressFromTree([lonelySpan]).length, 0, 'no press from non-link span');
+
+console.log('deeper inline nest a>span>b inherits through the chain');
+const a: NodeInfo = {
+  node: 'element',
+  tag: 'a',
+  tagType: 'inline',
+  attr: { href: 'https://example.com', clickIndex: 0 },
+  nodes: []
+};
+const span: NodeInfo = { node: 'element', tag: 'span', tagType: 'inline', attr: {}, nodes: [] };
+const bold: NodeInfo = {
+  node: 'element',
+  tag: 'b',
+  tagType: 'inline',
+  attr: {},
+  nodes: [{ node: 'text', text: 'deep' }]
+};
+inheritClickableAttrs(span, a);
+inheritClickableAttrs(bold, span);
+a.nodes = [span];
+span.nodes = [bold];
+assertEqual(bold.attr?.href, 'https://example.com', 'b inherits href via span');
+assertEqual(collectLinkPressFromTree([a])[0]?.link, 'https://example.com', 'deep nest still fires inherited href');
+
+console.log('child href is not overwritten by parent');
+const innerA: NodeInfo = {
+  node: 'element',
+  tag: 'a',
+  tagType: 'inline',
+  attr: { href: 'https://child.example' },
+  nodes: [{ node: 'text', text: 'child' }]
+};
+inheritClickableAttrs(innerA, a);
+assertEqual(innerA.attr?.href, 'https://child.example', 'nested <a> keeps its own href');
+
+console.log('onClick also propagates to nested inline');
+const clickSpan: NodeInfo = {
+  node: 'element',
+  tag: 'span',
+  tagType: 'inline',
+  attr: { onClick: 'handleSpanClick' },
+  nodes: []
+};
+const innerB: NodeInfo = {
+  node: 'element',
+  tag: 'b',
+  tagType: 'inline',
+  attr: {},
+  nodes: [{ node: 'text', text: 'tap' }]
+};
+inheritClickableAttrs(innerB, clickSpan);
+assertEqual(innerB.attr?.onClick, 'handleSpanClick', 'nested inline inherits onClick');
+assertEqual(resolveLinkPress(innerB, 'tap').eventFnName, 'handleSpanClick', 'resolveLinkPress exposes inherited onClick');
+
+console.log('isInlinePushNode still honors clickIndex');
+const pushed: NodeInfo = {
+  node: 'element',
+  tag: 'span',
+  tagType: 'inline',
+  isInlinePushNode: true,
+  attr: { href: 'http://www.baidu.com', clickIndex: 1 },
+  nodes: [
+    { node: 'text', text: 'before' },
+    { node: 'text', text: 'link' }
+  ]
+};
+assert(!shouldFireNodeClick(pushed, 0), 'index 0 does not fire when clickIndex is 1');
+assert(shouldFireNodeClick(pushed, 1), 'clickIndex text does fire');
+
+console.log('block children do not inherit');
+const block: NodeInfo = { node: 'element', tag: 'div', tagType: 'block', attr: {} };
+inheritClickableAttrs(block, a);
+assertEqual(block.attr?.href, undefined, 'block child does not inherit href');
+
+if (failed) {
+  console.error(`\n${failed} failed, ${passed} passed`);
+  process.exit(1);
+}
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
## Summary
- `<a href="..."><span>text</span></a>` was unclickable because `spanBuilder` only looked at the immediate parent.
- Nested inline nodes now inherit the ancestor `href` / `onClick` so `onLinkPress` still fires.

Fixes #111

## Test plan
- [ ] `node --experimental-strip-types library/test/click.test.ts`
- [ ] Nested `<a><span>a标签</span></a>` is clickable