### PR TITLE
fix: video 标签 poster 未应用到鸿蒙 Video.previewUri

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- 🐛 修复 video 标签 poster 未应用到鸿蒙 Video.previewUri [(#117)](https://github.com/asasugar/HPRichText/issues/117)
+
 ## [v3.1.0](https://github.com/asasugar/HPRichText/releases/tag/v3.1.0) (2025-10-10)
 
 ### Features

--- a/library/src/main/ets/components/hprichtext/builder/video.ets
+++ b/library/src/main/ets/components/hprichtext/builder/video.ets
@@ -5,7 +5,8 @@ import { _commonClick } from '../common';
 @Builder
 export function videoBuilder(item: NodeInfo, onLinkPress?: LinkPressMethod) {
   Video({
-    src: item.attr?.src
+    src: item.attr?.src,
+    previewUri: item.attr?.poster
   })
     .fancyVideo(item?.artUIStyleObject, item?.attr)
     .onClick((event) => {

--- a/library/src/main/ets/components/hprichtext/index.d.ts
+++ b/library/src/main/ets/components/hprichtext/index.d.ts
@@ -63,6 +63,7 @@ export interface FancyImageOptions extends ShapeAttr {
 export interface FancyVideoOptions {
   width?: string | number;
   height?: string | number;
+  previewUri?: string;
 }
 
 export interface FancyTextInputOptions {

--- a/test/videoPoster.test.mjs
+++ b/test/videoPoster.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * Node parser/builder test for HTML video poster → HarmonyOS Video.previewUri.
+ * Bundles the HTML parser (no HarmonyOS device required).
+ */
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const parserEntry = join(repoRoot, 'library/src/main/ets/common/utils/html/html-parser.ts');
+const videoBuilderPath = join(repoRoot, 'library/src/main/ets/components/hprichtext/builder/video.ets');
+
+function bundle(entry) {
+  const outDir = mkdtempSync(join(tmpdir(), 'hprichtext-videoposter-'));
+  const outfile = join(outDir, 'bundle.cjs');
+  const result = spawnSync('npx', [
+    '--yes',
+    'esbuild',
+    entry,
+    '--bundle',
+    '--platform=node',
+    '--format=cjs',
+    `--outfile=${outfile}`
+  ], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`esbuild failed for ${entry}:\n${result.stderr || result.stdout}`);
+  }
+  return createRequire(import.meta.url)(outfile);
+}
+
+function findFirstElement(nodes, tag) {
+  if (!nodes?.length) {
+    return undefined;
+  }
+  for (const node of nodes) {
+    if (node.node === 'element' && (!tag || node.tag === tag)) {
+      return node;
+    }
+    const child = findFirstElement(node.nodes, tag);
+    if (child) {
+      return child;
+    }
+  }
+  return undefined;
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) {
+    throw new Error(message);
+  }
+}
+
+const HTMLParser = bundle(parserEntry).default;
+
+const posterUrl = 'https://example.com/poster.jpg';
+const srcUrl = 'https://example.com/clip.mp4';
+const parser = new HTMLParser({
+  content: `<video height="500px" src="${srcUrl}" poster="${posterUrl}"></video>`
+});
+const videoNode = findFirstElement(parser.html2json().nodes, 'video');
+assert(videoNode, 'parsed a video element');
+assertEqual(videoNode.attr?.src, srcUrl, 'video src is preserved');
+assertEqual(videoNode.attr?.poster, posterUrl, 'video poster attr is preserved for previewUri');
+
+const noPosterParser = new HTMLParser({
+  content: `<video src="${srcUrl}"></video>`
+});
+const noPosterNode = findFirstElement(noPosterParser.html2json().nodes, 'video');
+assertEqual(noPosterNode?.attr?.poster, undefined, 'absent poster must not invent a poster attr');
+
+const builderSource = readFileSync(videoBuilderPath, 'utf8');
+assert(
+  /previewUri\s*:\s*item\.attr\?\.poster/.test(builderSource),
+  'videoBuilder must pass Video.previewUri from the poster attr'
+);
+assert(
+  !builderSource.includes('.previewUri(') || /previewUri\s*:\s*item\.attr\?\.poster/.test(builderSource),
+  'previewUri mapping must come from the HTML poster attr'
+);
+
+console.log('video poster → previewUri pipeline tests passed');


### PR DESCRIPTION
## Summary
- HTML `<video poster="...">` is now passed through to HarmonyOS `Video.previewUri`.
- `FancyVideoOptions` includes the matching `previewUri` type; no extra video features were added.
- A node parser/builder test checks that the poster attr is preserved and that `videoBuilder` wires `previewUri: item.attr?.poster`.

Fixes #117

## Test plan
- [ ] `node test/videoPoster.test.mjs`
- [ ] `<video poster="cover.png" src="...">` shows the cover via `Video.previewUri`