### PR TITLE
feat: 新增 scrollBar 属性，支持滚动时隐藏右侧滚动条

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,29 @@ Button('改变数据').onClick(() => {
 |------------|---------|----|-------|--------------------------|
 | needScroll | Boolean | 否  | false | 富文本内容超过一屏幕是否使用Scroll组件包裹 |
 
+## scrollBar属性
+
+| 名称        | 类型       | 必填 | 默认值           | 描述                                                                                         |
+|-----------|----------|----|----------------|--------------------------------------------------------------------------------------------|
+| scrollBar | BarState | 否  | BarState.Auto | `needScroll` 为 true 时，控制内部 Scroll 滚动条显示状态。`BarState.Auto` 滚动时显示，`BarState.On` 常驻显示，`BarState.Off` 隐藏 |
+
+V1 / Observed 用法：
+
+```ets
+HPRichText({
+  richTextOption: $richTextOption,
+  needScroll: true,
+  scrollBar: BarState.Off,
+})
+```
+
+V2 用法：
+
+```ets
+this.richTextModel.needScroll = true;
+this.richTextModel.scrollBar = BarState.Off;
+```
+
 ## onLinkPress属性
 
 | 名称          | 类型            | 必填 | 默认值  | 描述                                                                                                                            |

--- a/library/README.md
+++ b/library/README.md
@@ -305,6 +305,29 @@ Button('改变数据').onClick(() => {
 |------------|---------|----|-------|--------------------------|
 | needScroll | Boolean | 否  | false | 富文本内容超过一屏幕是否使用Scroll组件包裹 |
 
+## scrollBar属性
+
+| 名称        | 类型       | 必填 | 默认值           | 描述                                                                                         |
+|-----------|----------|----|----------------|--------------------------------------------------------------------------------------------|
+| scrollBar | BarState | 否  | BarState.Auto | `needScroll` 为 true 时，控制内部 Scroll 滚动条显示状态。`BarState.Auto` 滚动时显示，`BarState.On` 常驻显示，`BarState.Off` 隐藏 |
+
+V1 / Observed 用法：
+
+```ets
+HPRichText({
+  richTextOption: $richTextOption,
+  needScroll: true,
+  scrollBar: BarState.Off,
+})
+```
+
+V2 用法：
+
+```ets
+this.richTextModel.needScroll = true;
+this.richTextModel.scrollBar = BarState.Off;
+```
+
 ## onLinkPress属性
 
 | 名称          | 类型            | 必填 | 默认值  | 描述                                                                                                                            |

--- a/library/src/main/ets/components/hprichtext/HPRichText.ets
+++ b/library/src/main/ets/components/hprichtext/HPRichText.ets
@@ -26,6 +26,8 @@ import { _isNeedRenderText, _setDefaultArtUI, getRandomKey } from './common';
 export struct HPRichText {
   @Link @Watch('onUpdateRichTextOption') richTextOption: RichTextOption;
   @Prop needScroll: boolean;
+  // 默认 Auto，与 Scroll 组件默认行为一致（滚动时显示滚动条）
+  @Prop scrollBar: BarState = BarState.Auto;
   onLinkPress?: LinkPressMethod;
   @State htmlJson: HtmlParserResult = {
     nodes: []
@@ -150,6 +152,7 @@ export struct HPRichText {
         }
         .alignItems(HorizontalAlign?.Start)
       }
+      .scrollBar(this.scrollBar ?? BarState.Auto)
     } else {
       Column() {
         this.nodesBuilder({ nodes: this.htmlJson.nodes });

--- a/library/src/main/ets/components/hprichtext/HPRichTextV2.ets
+++ b/library/src/main/ets/components/hprichtext/HPRichTextV2.ets
@@ -152,6 +152,7 @@ export struct HPRichTextV2 {
         scrollForward: NestedScrollMode.PARENT_FIRST,
         scrollBackward: NestedScrollMode.SELF_FIRST
       })
+      .scrollBar(this.richTextModel.scrollBar ?? BarState.Auto)
     } else {
       Column() {
         this.nodesBuilder({ nodes: this.htmlJson.nodes });

--- a/library/src/main/ets/components/hprichtext/ObservedHPRichText.ets
+++ b/library/src/main/ets/components/hprichtext/ObservedHPRichText.ets
@@ -21,6 +21,8 @@ import { _isNeedRenderText, _setDefaultArtUI, getRandomKey } from './common';
 export struct ObservedHPRichText {
   @ObjectLink @Watch('onUpdateRichTextOption') observedRichTextOption: RichTextOptionModel;
   @Prop needScroll: boolean;
+  // 默认 Auto，与 Scroll 组件默认行为一致（滚动时显示滚动条）
+  @Prop scrollBar: BarState = BarState.Auto;
   onLinkPress?: LinkPressMethod;
   @State htmlJson: HtmlParserResult = {
     nodes: []
@@ -143,6 +145,7 @@ export struct ObservedHPRichText {
         }
         .alignItems(HorizontalAlign?.Start)
       }
+      .scrollBar(this.scrollBar ?? BarState.Auto)
     } else {
       Column() {
         this.nodesBuilder({ nodes: this.htmlJson.nodes });

--- a/library/src/main/ets/components/hprichtext/model/RichTextOptionModelV2.ets
+++ b/library/src/main/ets/components/hprichtext/model/RichTextOptionModelV2.ets
@@ -22,6 +22,9 @@ export class RichTextOptionModelV2 {
   // needScroll变化时自动刷新组件
   @Trace
   needScroll?: boolean = true;
+  // scrollBar变化时自动刷新组件，默认 Auto（滚动时显示滚动条）
+  @Trace
+  scrollBar?: BarState = BarState.Auto;
   // 是否开启Text的copy功能，默认为false
   @Trace
   copyEnable: boolean = false;


### PR DESCRIPTION
## Summary
- When `needScroll` is true, the inner `Scroll` did not expose `scrollBar`, so the right bar could not be hidden.
- Add `scrollBar` on `HPRichText`, `ObservedHPRichText`, and `RichTextOptionModelV2`.
- Default remains `BarState.Auto`. Set `BarState.Off` to hide the bar while still scrolling.

Fixes #112

## Test plan
- [ ] `needScroll: true` without `scrollBar` still shows the bar (same as before)
- [ ] `needScroll: true, scrollBar: BarState.Off` hides the bar
- [ ] V2 `richTextModel.scrollBar = BarState.Off` works the same